### PR TITLE
Add derived compilation mode and add option to run with silent argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ The recommended way to install PlatformIO-Mode is using [MELPA](https://melpa.or
 
 ### Configuration
 
-`platformio-setup-compile-buffer` is provided to simplify setting up the compilation
-buffer. It enables scrolling and ansi-colors.
-
-
 Here is a sample config using PlatformIO-Mode in conjuction with [company](http://company-mode.github.io/), [irony](https://github.com/Sarcasm/irony-mode), [flycheck](http://www.flycheck.org/) and [flycheck-irony](https://github.com/Sarcasm/flycheck-irony).
 
 ```elisp
@@ -71,6 +67,4 @@ Here is a sample config using PlatformIO-Mode in conjuction with [company](http:
 ;; Setup irony for flycheck.
 (add-hook 'flycheck-mode-hook 'flycheck-irony-setup)
 
-;; Enable scrolling and colours in the compile buffer.
-(platformio-setup-compile-buffer)
 ```

--- a/platformio-mode.el
+++ b/platformio-mode.el
@@ -44,6 +44,11 @@
   :group 'platformio
   :type 'string)
 
+(defcustom platformio-mode-silent nil
+  "Run platformio commands with the silent argument."
+  :group 'platformio
+  :type 'boolean)
+
 (define-compilation-mode platformio-compilation-mode "PIOCompilation"
   "Platformio specific `compilation-mode' derivative."
   (setq-local compilation-scroll-output t)
@@ -70,7 +75,7 @@
 
 
 ;;; Internal functions
-(defun platformio--run-cmd (target)
+(defun platformio--exec (target)
   "Call `platformio ... TARGET' in the root of the project."
   (let ((default-directory (projectile-project-root))
         (cmd (concat "platformio -f -c emacs " target)))
@@ -80,37 +85,47 @@
                                                       default-directory)))
     (compilation-start cmd 'platformio-compilation-mode)))
 
+(defun platformio--silent-arg ()
+  (if platformio-mode-silent
+      "-s "
+    nil))
+
+(defun platformio--run (runcmd &optional NOSILENT)
+  (platformio--exec (concat "run "
+                            (unless NOSILENT
+                              (platformio--silent-arg))
+                            runcmd)))
 
 ;;; User commands
-(defun platformio-build ()
+(defun platformio-build (arg)
   "Build PlatformIO project."
-  (interactive)
-  (platformio--run-cmd "run"))
+  (interactive "P")
+  (platformio--run nil arg))
 
-(defun platformio-upload ()
+(defun platformio-upload (arg)
   "Upload PlatformIO project to device."
-  (interactive)
-  (platformio--run-cmd "run -t upload"))
+  (interactive "P")
+  (platformio--run "-t upload" arg))
 
-(defun platformio-programmer-upload ()
+(defun platformio-programmer-upload (arg)
   "Upload PlatformIO project to device using external programmer."
-  (interactive)
-  (platformio--run-cmd "run -t program"))
+  (interactive "P")
+  (platformio--run "-t program" arg))
 
-(defun platformio-spiffs-upload ()
+(defun platformio-spiffs-upload (arg)
   "Upload SPIFFS to device."
-  (interactive)
-  (platformio--run-cmd "run -t uploadfs"))
+  (interactive "P")
+  (platformio--run "-t uploadfs" arg))
 
-(defun platformio-clean ()
+(defun platformio-clean (arg)
   "Clean PlatformIO project."
-  (interactive)
-  (platformio--run-cmd "run -t clean"))
+  (interactive "P")
+  (platformio--run "-t clean" arg))
 
-(defun platformio-update ()
+(defun platformio-update (arg)
   "Update installed PlatformIO libraries."
   (interactive)
-  (platformio--run-cmd "update"))
+  (platformio--exec "update"))
 
 
 ;;; Minor mode

--- a/platformio-mode.el
+++ b/platformio-mode.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (require 'projectile)
+(require 'compile)
 
 ;;; Customization
 (defgroup platformio nil
@@ -43,18 +44,21 @@
   :group 'platformio
   :type 'string)
 
+(define-compilation-mode platformio-compilation-mode "PIOCompilation"
+  "Platformio specific `compilation-mode' derivative."
+  (setq-local compilation-scroll-output t)
+  (require 'ansi-color)
+  (add-hook 'compilation-filter-hook
+            'platformio-compilation-filter-hook nil t))
+
+(defun platformio-compilation-filter-hook ()
+  (when (eq major-mode 'platformio-compilation-mode)
+    (ansi-color-apply-on-region compilation-filter-start (point-max))))
 
 ;;; User setup functions
 (defun platformio-setup-compile-buffer ()
-  "Enables ansi-colors and scrolling in the compilation buffer."
-  (require 'ansi-color)
-
-  (add-hook 'compilation-filter-hook
-            (lambda ()
-              (when (eq major-mode 'compilation-mode)
-                (ansi-color-apply-on-region compilation-filter-start (point-max)))))
-
-  (setq compilation-scroll-output t))
+  "Deprecated function."
+  (warn "The function platformio-setup-compile-buffer is deprecated, remove it from your config!"))
 
 
 (defun platformio-conditionally-enable ()
@@ -74,7 +78,7 @@
                        (lambda ()
                          (projectile-project-buffer-p (current-buffer)
                                                       default-directory)))
-    (compilation-start cmd)))
+    (compilation-start cmd 'platformio-compilation-mode)))
 
 
 ;;; User commands

--- a/platformio-mode.el
+++ b/platformio-mode.el
@@ -45,12 +45,12 @@
   :type 'string)
 
 (defcustom platformio-mode-silent nil
-  "Run platformio commands with the silent argument."
+  "Run PlatformIO commands with the silent argument."
   :group 'platformio
   :type 'boolean)
 
 (define-compilation-mode platformio-compilation-mode "PIOCompilation"
-  "Platformio specific `compilation-mode' derivative."
+  "PlatformIO specific `compilation-mode' derivative."
   (setq-local compilation-scroll-output t)
   (require 'ansi-color)
   (add-hook 'compilation-filter-hook


### PR DESCRIPTION
This change removes the need of the `platformio-setup-compile-buffer` function by enforcing that set up in it's own derived mode without affecting global compilation mode settings.