### PR TITLE
Warn users if they're not in a projectile project

### DIFF
--- a/platformio-mode.el
+++ b/platformio-mode.el
@@ -79,6 +79,8 @@
   "Call `platformio ... TARGET' in the root of the project."
   (let ((default-directory (projectile-project-root))
         (cmd (concat "platformio -f -c emacs " target)))
+    (unless default-directory
+      (user-error "Not in a projectile project, aborting"))
     (save-some-buffers (not compilation-ask-about-save)
                        (lambda ()
                          (projectile-project-buffer-p (current-buffer)


### PR DESCRIPTION
Currently if users aren't in a projectile project and try to run a platformio command, they receive a cryptic error about an argument not being `stringp`.

<img width="291" alt="tmp 2021-04-22 14-19-32" src="https://user-images.githubusercontent.com/43040593/115766363-e1385a80-a375-11eb-8714-79ec3cedf71c.png">

Instead now they will get a more helpful message telling them they're not in a projectile project.

<img width="285" alt="tmp 2021-04-22 14-21-20" src="https://user-images.githubusercontent.com/43040593/115766483-0927be00-a376-11eb-8a66-0936c0135a60.png">
