### PR TITLE
Add boards list mode

### DIFF
--- a/Cask
+++ b/Cask
@@ -4,7 +4,5 @@
 (package-file "platformio-mode.el")
 
 (development
- (depends-on "projectile"))
- 
- 
- 
+ (depends-on "projectile")
+ (depends-on "async"))

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following keybindings are currently available.
 | Clean                   | `C-c i c` |
 | Update                  | `C-c i d` |
 | Update Workspace        | `C-c i i` |
+| Boards List             | `C-c i l` |
 
 
 ## Installation

--- a/platformio-mode.el
+++ b/platformio-mode.el
@@ -114,7 +114,7 @@
 
 ;;; Board list functions
 (defun platformio--add-board (board)
-  "Add a BOARD to a PlatformIO porject."
+  "Add a BOARD to a PlatformIO project."
   (platformio--exec (string-join (list "init --ide emacs --board " board))))
 
 (defun platformio--build-board-table (_autoignore _noconfirm)

--- a/platformio-mode.el
+++ b/platformio-mode.el
@@ -180,7 +180,7 @@
   (setq tabulated-list-sort-key nil)
   (setq tabulated-list-padding 2)
   (tabulated-list-init-header)
-  (setq revert-buffer-function #'platformio--build-table))
+  (setq revert-buffer-function #'platformio--build-board-table))
 
 
 ;;; User commands

--- a/platformio-mode.el
+++ b/platformio-mode.el
@@ -79,6 +79,8 @@
   "Call `platformio ... TARGET' in the root of the project."
   (let ((default-directory (projectile-project-root))
         (cmd (concat "platformio -f -c emacs " target)))
+    (unless default-directory
+      (user-error "Not in a projectile project, aborting"))
     (save-some-buffers (not compilation-ask-about-save)
                        (lambda ()
                          (projectile-project-buffer-p (current-buffer)

--- a/platformio-mode.el
+++ b/platformio-mode.el
@@ -118,7 +118,7 @@
   (platformio--exec (string-join (list "init --ide emacs --board " board))))
 
 (defun platformio--build-board-table (_autoignore _noconfirm)
-  "Return a list of all boards supported by PlatforIO."
+  "Return a list of all boards supported by PlatformIO."
   (setq revert-buffer-in-progress-p t)
   (setq mode-line-process ":refreshing")
   (async-start

--- a/platformio-mode.el
+++ b/platformio-mode.el
@@ -254,6 +254,7 @@
    ["Upload using External Programmer" platformio-programmer-upload]
    ["Upload SPIFFS" platformio-spiffs-upload]
    "--"
+   ["Add Boards" platformio-boards]
    ["Clean Project" platformio-clean]
    ["Update Project Libraries" platformio-update]
    ["Update Project Workspace and Index" platformio-init-update-workspace]))


### PR DESCRIPTION
Adds a command that displays a list of all boards and their details. Allows users to easily add new boards to their projects or initialize new projects more easily.

![image](https://user-images.githubusercontent.com/43040593/116155383-01d71c00-a6b8-11eb-8be3-a742cfcb8d3d.png)
