### PR TITLE
Define a projectile platformio project type if it does not already exist

### DIFF
--- a/platformio-mode.el
+++ b/platformio-mode.el
@@ -109,10 +109,19 @@
 (defun platformio--run (runcmd &optional NOTSILENT)
   "Execute command RUNCMD, optionally NOTSILENT."
   (platformio--exec (concat "run "
-                  (unless NOTSILENT
-                    (platformio--silent-arg))
-                  runcmd)))
+                            (unless NOTSILENT
+                              (platformio--silent-arg))
+                            runcmd)))
 
+(defun platformio--projectile-has-platformio-project-p ()
+  "Determine whether Projectile knows about platformio projects."
+  (seq-find
+   #'(lambda (projectile-spec)
+       (let ((marker-files (plist-get (cdr projectile-spec) 'marker-files)))
+         (platformio-project-file "platformio.ini")
+         (if (consp marker-files)
+             (member platformio-project-file marker-files))))
+   projectile-project-types))
 
 ;;; Board list functions
 (defun platformio--add-board (board)
@@ -278,6 +287,10 @@
   :keymap platformio-mode-map
   :group 'platformio
   :require 'platformio)
+
+(if (not (platformio--projectile-has-platformio-project-p))
+    (projectile-register-project-type 'platformio '("platformio.ini") :project-file "platformio.ini"))
+
 
 (provide 'platformio-mode)
 ;;; platformio-mode.el ends here


### PR DESCRIPTION
Ahoy! This change adds a simple function to define a Projectile PlatformIO project type if it does not already exist. Not sure why, but I couldn't get the minor mode working without letting Projectile know that PlatformIO projects exist.