### PR TITLE
Remove projectile dependency and use Emacs' built-in project.el

### DIFF
--- a/Cask
+++ b/Cask
@@ -4,5 +4,4 @@
 (package-file "platformio-mode.el")
 
 (development
- (depends-on "projectile")
  (depends-on "async"))


### PR DESCRIPTION
Removes dependency on projectile by using the functionality of the built-in `project.el`. Closes issue #24 